### PR TITLE
Fix TMPDIR location

### DIFF
--- a/io.github.thaunknown.miru.yaml
+++ b/io.github.thaunknown.miru.yaml
@@ -14,7 +14,7 @@ finish-args:
   - --own-name=org.mpris.MediaPlayer2.chromium.instance3
   - --socket=pulseaudio
   - --filesystem=xdg-videos:rw
-  - --filesystem=xdg-cache:rw
+  - --filesystem=xdg-cache:create
   - --filesystem=xdg-run/discord-ipc-0:ro
 modules:
   - name: miru

--- a/io.github.thaunknown.miru.yaml
+++ b/io.github.thaunknown.miru.yaml
@@ -14,6 +14,7 @@ finish-args:
   - --own-name=org.mpris.MediaPlayer2.chromium.instance3
   - --socket=pulseaudio
   - --filesystem=xdg-videos:rw
+  - --filesystem=xdg-cache:rw
   - --filesystem=xdg-run/discord-ipc-0:ro
 modules:
   - name: miru

--- a/io.github.thaunknown.miru.yaml
+++ b/io.github.thaunknown.miru.yaml
@@ -38,7 +38,7 @@ modules:
       - type: script
         dest-filename: miru-run
         commands:
-          - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
+          - export TMPDIR="$XDG_CACHE_HOME/app/$FLATPAK_ID"
           - zypak-wrapper /app/bin/miru/miru "$@"
       - type: file
         path: io.github.thaunknown.miru.metainfo.xml


### PR DESCRIPTION
Change TMPDIR to the XDG_CACHE_HOME specification instead of XDG_RUNTIME_DIR because of limited filesystem concerns in some linux distros.

I don't quiet understand why TMPDIR is [on capacitor](https://github.com/ThaUnknown/miru/blob/e9335b1f6fa1737e3133ec5171d25cfb1404c1f8/capacitor/src/main.js#L34) instead of common, since its (as far as I understood) used for all platforms, seems a bit weird to me, took me some time to find where the actual torrent path was being set. I'll just assume the lookup to TMPDIR won't change between target builds/platforms (?).

This is probably not the best way to fix it, but it shouldn't require changing stuff upstream, which is good because miru is release only.

I don't use flatpak or a non-reproducible GNU/Linux distro so, if anyone can test this or suggest changes, some help would be appreciated.