### PR TITLE
Updated outdated stuff :)

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,3 @@
 {
-    "only-arches": ["x86_64"],
-    "disable-external-data-checker": true
+    "only-arches": ["x86_64"]
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,4 @@
 {
     "only-arches": ["x86_64"],
-    "automerge-flathubbot-prs": true,
     "disable-external-data-checker": true
 }

--- a/io.github.thaunknown.miru.metainfo.xml
+++ b/io.github.thaunknown.miru.metainfo.xml
@@ -31,7 +31,7 @@
     </description>
     <screenshots>
         <screenshot type="default">
-            <image>https://github.com/ThaUnknown/miru/blob/master/docs/out.gif</image>
+            <image>https://raw.githubusercontent.com/ThaUnknown/miru/refs/heads/master/web/static/app_original.png</image>
         </screenshot>
     </screenshots>
     <releases>

--- a/io.github.thaunknown.miru.metainfo.xml
+++ b/io.github.thaunknown.miru.metainfo.xml
@@ -31,7 +31,7 @@
     </description>
     <screenshots>
         <screenshot type="default">
-            <image>https://raw.githubusercontent.com/ThaUnknown/miru/master/docs/show.gif</image>
+            <image>https://github.com/ThaUnknown/miru/blob/master/docs/out.gif</image>
         </screenshot>
     </screenshots>
     <releases>

--- a/io.github.thaunknown.miru.metainfo.xml
+++ b/io.github.thaunknown.miru.metainfo.xml
@@ -12,11 +12,14 @@
         <category>AudioVideo</category>
         <category>Video</category>
     </categories>
-    <url type="homepage">https://github.com/ThaUnknown/miru</url>
-    <url type="faq">https://github.com/ThaUnknown/miru/blob/master/docs/faq.md</url>
     <url type="bugtracker">https://github.com/ThaUnknown/miru/issues</url>
-    <url type="help">https://discord.com/invite/Z87Nh7c4Ac</url>
+    <url type="homepage">https://github.com/ThaUnknown/miru</url>
     <url type="donation">https://github.com/sponsors/ThaUnknown</url>
+    <url type="contact">https://miru.watch/contact/</url>
+    <url type="faq">https://miru.watch/faq/</url>
+    <url type="contribute">https://github.com/ThaUnknown/miru</url>
+    <url type="help">https://discord.com/invite/Z87Nh7c4Ac</url>
+    
     <description>
         <p>
             Bittorrent streaming software for cats. Stream anime torrents, real-time with no waiting for downloads.
@@ -24,7 +27,9 @@
     </description>
         <screenshots>
         <screenshot type="default">
-            <image>https://raw.githubusercontent.com/ThaUnknown/miru/master/docs/show.gif</image>
+            <image>https://raw.githubusercontent.com/ThaUnknown/miru/master/docs/homepage.png</image>
+            <image>https://raw.githubusercontent.com/ThaUnknown/miru/master/docs/anime-page.png</image>
+            <image>https://raw.githubusercontent.com/ThaUnknown/miru/master/docs/search.png</image>
         </screenshot>
     </screenshots>
     <releases>

--- a/io.github.thaunknown.miru.metainfo.xml
+++ b/io.github.thaunknown.miru.metainfo.xml
@@ -28,12 +28,15 @@
     <screenshots>
       <screenshot type="default">
         <image xml:space="preserve">https://raw.githubusercontent.com/ThaUnknown/miru/master/docs/homepage.png</image>
+        <caption>Homepage of the App</caption>
       </screenshot>
       <screenshot>
         <image xml:space="preserve">https://raw.githubusercontent.com/ThaUnknown/miru/master/docs/search.png</image>
+        <caption>Search Interface of the App</caption>
       </screenshot>
       <screenshot>
         <image xml:space="preserve">https://raw.githubusercontent.com/ThaUnknown/miru/master/docs/anime-page.png</image>
+        <caption>Anime Discription and episod selector</caption>
       </screenshot>
     </screenshots>
     <releases>

--- a/io.github.thaunknown.miru.metainfo.xml
+++ b/io.github.thaunknown.miru.metainfo.xml
@@ -3,7 +3,7 @@
     <id type="desktop">io.github.thaunknown.miru</id>
     <launchable type="desktop-id">io.github.thaunknown.miru.desktop</launchable>
     <name>Miru</name>
-    <summary>Miru - Bittorrent streaming software for cats</summary>
+    <summary>Bittorrent anime streaming software for cats</summary>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0</project_license>
     <content_rating type="oars-1.1"/>
@@ -23,6 +23,10 @@
     <description>
         <p>
             Bittorrent streaming software for cats. Stream anime torrents, real-time with no waiting for downloads.
+            
+            Find and download torrents, watch trailers, manage your list, search, browse and discover anime, watch together with friends and more, all in the same interface. No need to open multiple apps, tabs, everything shipped in one package.
+
+            Feature rich, with a perfect balance of simplicity, with no restrictions, paywalls or tracking. You want it, Miru does it. No need for multi-layer-deep configuration, complex setup, or high entry levels, Miru comes perfectly functional out of the box.
         </p>
     </description>
     <screenshots>

--- a/io.github.thaunknown.miru.metainfo.xml
+++ b/io.github.thaunknown.miru.metainfo.xml
@@ -37,6 +37,9 @@
       </screenshot>
     </screenshots>
     <releases>
+        <release version="5.3.1" date="2024-08-18">
+            <description></description>
+        </release>
         <release version="4.5.10" date="2024-01-20"/>
         <release version="4.5.9" date="2024-01-09"/>
         <release version="4.5.8" date="2023-12-21"/>

--- a/io.github.thaunknown.miru.metainfo.xml
+++ b/io.github.thaunknown.miru.metainfo.xml
@@ -25,12 +25,16 @@
             Bittorrent streaming software for cats. Stream anime torrents, real-time with no waiting for downloads.
         </p>
     </description>
-        <screenshots>
-        <screenshot type="default">
-            <image>https://raw.githubusercontent.com/ThaUnknown/miru/master/docs/homepage.png</image>
-            <image>https://raw.githubusercontent.com/ThaUnknown/miru/master/docs/anime-page.png</image>
-            <image>https://raw.githubusercontent.com/ThaUnknown/miru/master/docs/search.png</image>
-        </screenshot>
+    <screenshots>
+      <screenshot type="default">
+        <image xml:space="preserve">https://raw.githubusercontent.com/ThaUnknown/miru/master/docs/homepage.png</image>
+      </screenshot>
+      <screenshot>
+        <image xml:space="preserve">https://raw.githubusercontent.com/ThaUnknown/miru/master/docs/search.png</image>
+      </screenshot>
+      <screenshot>
+        <image xml:space="preserve">https://raw.githubusercontent.com/ThaUnknown/miru/master/docs/anime-page.png</image>
+      </screenshot>
     </screenshots>
     <releases>
         <release version="4.5.10" date="2024-01-20"/>

--- a/io.github.thaunknown.miru.metainfo.xml
+++ b/io.github.thaunknown.miru.metainfo.xml
@@ -30,18 +30,9 @@
         </p>
     </description>
     <screenshots>
-      <screenshot type="default">
-        <image xml:space="preserve">https://raw.githubusercontent.com/ThaUnknown/miru/master/docs/homepage.png</image>
-        <caption>Homepage of the App</caption>
-      </screenshot>
-      <screenshot>
-        <image xml:space="preserve">https://raw.githubusercontent.com/ThaUnknown/miru/master/docs/search.png</image>
-        <caption>Search Interface of the App</caption>
-      </screenshot>
-      <screenshot>
-        <image xml:space="preserve">https://raw.githubusercontent.com/ThaUnknown/miru/master/docs/anime-page.png</image>
-        <caption>Anime Discription and episod selector</caption>
-      </screenshot>
+        <screenshot type="default">
+            <image>https://raw.githubusercontent.com/ThaUnknown/miru/master/docs/show.gif</image>
+        </screenshot>
     </screenshots>
     <releases>
         <release version="5.3.1" date="2024-08-18">

--- a/io.github.thaunknown.miru.yaml
+++ b/io.github.thaunknown.miru.yaml
@@ -10,8 +10,8 @@ finish-args:
   - --device=dri
   - --share=ipc
   - --share=network
-  - --socket=fallback-x11
   - --socket=wayland
+  - --socket=x11
   - --own-name=org.mpris.MediaPlayer2.chromium.instance3
   - --socket=pulseaudio
   - --filesystem=xdg-videos:rw

--- a/io.github.thaunknown.miru.yaml
+++ b/io.github.thaunknown.miru.yaml
@@ -1,8 +1,8 @@
 app-id: io.github.thaunknown.miru
 base: org.electronjs.Electron2.BaseApp
-base-version: '22.08'
+base-version: '23.08'
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: miru-run
 separate-locales: false
@@ -11,10 +11,16 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=x11
+  - --socket=wayland
   - --own-name=org.mpris.MediaPlayer2.chromium.instance3
   - --socket=pulseaudio
   - --filesystem=xdg-videos:rw
   - --filesystem=xdg-run/discord-ipc-0:ro
+  # For inhibiting sleep
+  - --system-talk-name=org.freedesktop.login1
+  - --talk-name=org.gnome.SessionManager
+  - --talk-name=org.freedesktop.PowerManagement
+  - --talk-name=org.freedesktop.ScreenSaver
 modules:
   - name: miru
     buildsystem: simple

--- a/io.github.thaunknown.miru.yaml
+++ b/io.github.thaunknown.miru.yaml
@@ -50,8 +50,8 @@ modules:
         path: io.github.thaunknown.miru.metainfo.xml
       - type: file
         dest-filename: miru.AppImage
-        url: https://github.com/thaunknown/miru/releases/download/v4.5.10/linux-Miru-4.5.10.AppImage
-        sha512: 74ea063f16e9c6bdd29400bc60240e2c6dad93dfbad8c41ed1468baae437592b42cd86a02b7002c830ac67806e5af261d37434192b0f809bf2c17f4164d35584
+        url: https://github.com/thaunknown/miru/releases/download/v5.3.1/linux-Miru-5.3.1.AppImage
+        sha512: b2d8690fd8a866dd539358137d88510c884474deadaf0dcf2224cae7b94e1eaacd647cecbd59bc59cc2a7c615cbb5c344c16f1a1ef1884f5e7e5ed885a405e91
         only-arches: [x86_64]
         x-checker-data:
           type: json

--- a/io.github.thaunknown.miru.yaml
+++ b/io.github.thaunknown.miru.yaml
@@ -10,7 +10,6 @@ finish-args:
   - --device=dri
   - --share=ipc
   - --share=network
-  - --socket=wayland
   - --socket=x11
   - --own-name=org.mpris.MediaPlayer2.chromium.instance3
   - --socket=pulseaudio

--- a/io.github.thaunknown.miru.yaml
+++ b/io.github.thaunknown.miru.yaml
@@ -10,7 +10,7 @@ finish-args:
   - --device=dri
   - --share=ipc
   - --share=network
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --own-name=org.mpris.MediaPlayer2.chromium.instance3
   - --socket=pulseaudio

--- a/io.github.thaunknown.miru.yaml
+++ b/io.github.thaunknown.miru.yaml
@@ -10,8 +10,8 @@ finish-args:
   - --device=dri
   - --share=ipc
   - --share=network
-  - --socket=fallback-x11
   - --socket=wayland
+  - --socket=fallback-x11
   - --own-name=org.mpris.MediaPlayer2.chromium.instance3
   - --socket=pulseaudio
   - --filesystem=xdg-videos:rw

--- a/io.github.thaunknown.miru.yaml
+++ b/io.github.thaunknown.miru.yaml
@@ -11,7 +11,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=wayland
-  - --socket=fallback-x11
+  - --socket=x11
   - --own-name=org.mpris.MediaPlayer2.chromium.instance3
   - --socket=pulseaudio
   - --filesystem=xdg-videos:rw

--- a/io.github.thaunknown.miru.yaml
+++ b/io.github.thaunknown.miru.yaml
@@ -10,8 +10,8 @@ finish-args:
   - --device=dri
   - --share=ipc
   - --share=network
+  - --socket=fallback-x11
   - --socket=wayland
-  - --socket=x11
   - --own-name=org.mpris.MediaPlayer2.chromium.instance3
   - --socket=pulseaudio
   - --filesystem=xdg-videos:rw


### PR DESCRIPTION
### List of things I did 

- Updated Links on the pages and added some new ones too
- Added New Screenshots (taken from the video already under master branch) 
- Updated electron base version and freedesktop runtime version
- Added Wayland socket so that app can run in Wayland too
- Added sockets for inhibiting sleep while a video is playing, so the desktop doesn't go to sleep
- removed auto-merge-flathubot-prs which was causing app to not built as it's been deprecated now

@ThaUnknown So flathub has now made it that the PRs created by flathub-bot will not be merged automatically for "stability"  so whenever you do a release on main repo after some hours there will a PR from flathub-bot here, you just have to merge the PR in here manually.

Also, I tested the app by building it locally, and it worked properly so you can just merge this PR, and it will build the app after doing this one [PR](https://github.com/ThaUnknown/miru/pull/531) too.

I really hope this app to be in flatpak, just learned last night how Flatpaks are build. :)